### PR TITLE
README.md: fix formatting and path in example code snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,13 +92,14 @@ On Windows, the [ga-aem-forward-win](https://pypi.org/project/ga-aem-forward-win
 
 5. Install the Python gatdaem1d module:
 
-    cd GA-AEM/python/
-    pip install -e .
+```
+cd GA-AEM/python/
+pip install -e .
 
-    # Test the installation
-    cd examples
-    python skytem_example.py
-
+# Test the installation
+cd examples
+python integrate_skytem.py
+```
 
 
 ### Compile GA-AEM Python module on Ubuntu/Linux


### PR DESCRIPTION
Linebreaks and the pound symbol broke the github markdown renderer. I changed the example to a fenced code block instead.

Also, the file path to the example script was changed to an existing file. Perhaps other example scripts are better.

Before:
<img width="914" height="215" alt="{FDC81D11-D4D4-4B37-8B3B-76AABEDD6022}" src="https://github.com/user-attachments/assets/7cbbe478-c33b-47c5-85ea-01eb835e205b" />

After:
<img width="928" height="209" alt="{7A4D65B4-59E9-4453-873A-78694FFE89A4}" src="https://github.com/user-attachments/assets/2c672737-6b91-423f-be19-16def26d1445" />
