### PR TITLE
Clean up ga-aem ubuntu install script

### DIFF
--- a/scripts/cmake_build_script_ubuntu_gatdaem1d.sh
+++ b/scripts/cmake_build_script_ubuntu_gatdaem1d.sh
@@ -1,41 +1,39 @@
 #!/bin/sh
+set -e  # exit with error if a command fails
+set -x  # show commands while executing
 
 # This script is for compiling the forward code, gatdaem1d, from ga-aem, on Ubuntu (version >= 2.0.0)
 # See more detailed information on https://github.com/GeoscienceAustralia/ga-aem/blob/master/cmake_build_script_ubuntu.sh 
 
-# Install necessary packages in Ubuntu (tested on Ubuntu 22.04 LTS )
-sudo apt update
-sudo apt-get install -y build-essential
-sudo apt-get install -y libfftw3-dev libfftw3-bin libfftw3-double3
-sudo apt-get install -y libopenmpi-dev
-sudo apt-get install -y cmake build-essential libfftw3-dev libopenmpi-dev
-sudo apt remove -y --purge libfftw3-* fftw3
-sudo apt autoremove -y
-sudo apt update
-sudo apt install -y libfftw3-dev libfftw3-bin libfftw3-double3
-
-
+# Install necessary packages in Ubuntu (tested on Ubuntu 22.04 LTS and Debian 13)
+sudo sh -c '
+	apt-get update &&
+	apt-get install -y build-essential libfftw3-dev libfftw3-bin libfftw3-double3 libopenmpi-dev cmake pkg-config &&
+	apt-get autoremove -y'
 
 ## 1. Clone the ga-aem repository from Github
-git clone --recursive https://github.com/GeoscienceAustralia/ga-aem.git
+if ! test -d ga-aem
+then
+	git clone --recursive https://github.com/GeoscienceAustralia/ga-aem.git
+fi
 cd ga-aem
 
 ## 2. Compile GA-AEM
 
 # INSTALL_DIR is the directory for installing the build package
-export INSTALL_DIR=$PWD/install-ubuntu
+INSTALL_DIR="$PWD"/install-ubuntu
 
 # BUILD_DIR is a temporary directory for building (compiling and linking)
-export BUILD_DIR=$PWD/build-ubuntu
+BUILD_DIR="$PWD"/build-ubuntu
 
-mkdir $BUILD_DIR
-cd $BUILD_DIR
+mkdir -p "$BUILD_DIR"
+cd "$BUILD_DIR"
 
 # compile gatdaem1d
 cmake -Wno-dev -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DCMAKE_BUILD_TYPE=Release -DWITH_MPI=OFF -DWITH_NETCDF=OFF -DWITH_GDAL=OFF -DWITH_PETSC=OFF ..
 cmake --build . --target matlab-bindings --config=Release
 cmake --build . --target python-bindings --config=Release
-cmake --install . --prefix $INSTALL_DIR
+cmake --install . --prefix "$INSTALL_DIR"
 
 
 ## CHECK FOR shared library dependencies
@@ -44,8 +42,8 @@ readelf -d install-ubuntu/python/gatdaem1d/gatdaem1d.so  | grep 'Shared'
 
 ## 3. Install python module 
 echo  "installing from --> $INSTALL_DIR"
-cd $INSTALL_DIR/python 
+cd "$INSTALL_DIR"/python 
 pip install -e .
 
 ## 4. Test the installation
-python $INSTALL_DIR/python/examples/skytem_example.py
+python "$INSTALL_DIR"/python/examples/skytem_example.py


### PR DESCRIPTION
- exit immediately if a subcommand fails
- print commands to console before execution
- reduce number of sudo invocations
- clean up installation of apt packages
- quote variable references to avoid problems if PWD contains spaces
- mkdir: do not fail if build dir already exists
- git: do not clone if already cloned
- add pkg-config package, needed for cmake detection of fftw3 libs

Verified on Debian 13 Trixie